### PR TITLE
Pictures Viewer on GitHub Pages

### DIFF
--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -21,26 +21,36 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate data.js
+        env:
+          GIT_SHA: ${{ github.sha }}
         run: |
           import glob
           import json
           import os
-
+          from datetime import datetime
 
           PIC_ROOT = "Pictures/"
 
-          pics = {"gsc": {}, "xbm": {}}
-          for pic_type in pics.keys():
+          pics = {}
+          for pic_type in ["gsc", "xbm"]:
               for file in glob.glob(f"**/*.{pic_type}", recursive=True):
                   if os.path.islink(file):
-                      continue                
+                      continue
+
                   path, core = os.path.split(file.replace(PIC_ROOT, ""))
-                  if path not in pics[pic_type]:
-                      pics[pic_type][path] = []
-                  pics[pic_type][path].append(core)
+                  if path not in pics:
+                      pics[path] = []
+                  pics[path].append(core)
 
           with open("data_pics.json", "w") as outfile:
-              json.dump(pics, outfile)
+              data = {
+                  "pictures": pics,
+                  "version": {
+                      "date": datetime.now().isoformat(),
+                      "sha": os.environ.get("GIT_SHA", "unknown")[:7],
+                  },
+              }
+              json.dump(data, outfile)
         shell: python
 
       - name: Archive data JSON

--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -1,0 +1,74 @@
+# Publish new set of GitHub Pages when new GSC or XBM pictures are committed to main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/publish_github_pages.yml"
+      - "**/*.gsc"
+      - "**/*.xbm"
+
+name: Publish GitHub Pages
+
+jobs:
+  generate_data_js:
+    name: Generate Data JSON
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Generate data.js
+        run: |
+          import glob
+          import json
+          import os
+
+
+          PIC_ROOT = "Pictures/"
+
+          pics = {"gsc": {}, "xbm": {}}
+          for pic_type in pics.keys():
+              for file in glob.glob(f"**/*.{pic_type}", recursive=True):
+                  if os.path.islink(file):
+                      continue                
+                  path, core = os.path.split(file.replace(PIC_ROOT, ""))
+                  if path not in pics[pic_type]:
+                      pics[pic_type][path] = []
+                  pics[pic_type][path].append(core)
+
+          with open("data_pics.json", "w") as outfile:
+              json.dump(pics, outfile)
+        shell: python
+
+      - name: Archive data JSON
+        uses: actions/upload-artifact@v2
+        with:
+          name: data-pics-json
+          path: data_pics.json
+          retention-days: 5
+
+  update_gh_pages:
+    name: Update Data on GitHub Pages
+    needs: generate_data_js
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Download data JSON
+        uses: actions/download-artifact@v2
+        with:
+          name: data-pics-json
+
+      - name: Commit data json
+        run: |
+          git config --local user.name 'github-actions[bot]'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add data_pics.json
+          git commit -am "automated update of json data"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore generated data files
+data_*.json


### PR DESCRIPTION
This PR will create a GitHub Actions workflow that does the following steps:

1. Generate Data JSON - Generates a JSON file with all of name and path of all of the GSC and XBM files in this repository and uploads it as an action artifact
2. Update GH Pages - Downloads the artifact from the previous step and commits it to the _gh-pages_ branch which is the base for GitHub Pages

The workflow will run anytime a _push_ event occurs on the _main_ branch but also can be run manually through the `Actions` tab.

**Before this PR is merged** (or the action will fail until this is done) GitHub pages needs to be setup, to do this do the following.

1. Create a _gh-pages_ branch (via https://gist.github.com/ramnathv/2227408#gistcomment-2915143)
   1. Checkout an orphan (branch without history) branch `git checkout --orphan gh-pages`
   2. Confirm you are on the new _gh-pages_ branch using `git status`
   3. The branch will contain the files from _main_, which need to be removed, do a dry-run to see the files being removed `git rm -rf --dry-run .`
   4. Once you confirm that the existing files (_Pictures_ and _readme.md_) are removed remove them for real `git rm -rf .`
   5. Add a placeholder _index.html_ `touch index.html`
   6. Add the placeholder _index.html_ `git add index.html`
   7. Commit `git commit -a -m "Add index.html"`
   8. Push to origin/GitHub `git push origin gh-pages`
2. Enable _GitHub Pages_
   1. On GitHub go to _Settings_ for the project then _Pages_
   2. Under _Source_ select the _gh-pages_ branch
   3. Check _Enforce HTTPS_
   3. _Save_ and it will show you the URL the pages is available at, which should be https://venice1200.github.io/MiSTer_tty2oled_Pictures/
3. Once I see that the _gh-pages_ branch is available in the repository I will create a new PR that contains the code for the GitHub pages site (updated index.html and css/js files)
