### PR TITLE
fix: update github actions versions

### DIFF
--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate data.js
         env:
@@ -54,7 +54,7 @@ jobs:
         shell: python
 
       - name: Archive data JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: data-pics-json
           path: data_pics.json
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 
       - name: Download data JSON
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: data-pics-json
 


### PR DESCRIPTION
Update GitHub Actions workflow to remove call to deprecated actions and update to current